### PR TITLE
feat: support multiple arguments in function call parsing

### DIFF
--- a/parser/expressions.go
+++ b/parser/expressions.go
@@ -322,6 +322,33 @@ func (p *Parser) parseCall(funcExpr Expression) Expression {
 				},
 			}
 		}
+		args = append(args, first)
+
+		for p.current.Type == lexer.COMMA {
+			p.advance() // consume ','
+
+			// trailing comma: foo(a, b,)
+			if p.current.Type == lexer.RPAR {
+				break
+			}
+
+			arg := p.parseExpression(LOWEST)
+			if arg == nil {
+				p.syncTo(lexer.RPAR, lexer.NEWLINE, lexer.EOF)
+				if p.current.Type == lexer.RPAR {
+					p.advance()
+				}
+				return &Call{
+					Func: funcExpr,
+					Args: args,
+					Pos: Range{
+						Start: startPos,
+						End:   p.currentRange().End,
+					},
+				}
+			}
+			args = append(args, arg)
+		}
 	}
 
 	if p.current.Type != lexer.RPAR {


### PR DESCRIPTION
## Summary

- Add comma-separated argument parsing to `parseCall` with support for trailing commas and error recovery
- Add tests for multi-arg calls, nested calls, trailing commas, and expression arguments

## Changes

**`parser/expressions.go`**: After parsing the first argument, loop over commas to collect additional arguments. Handles trailing commas (`foo(a, b,)`) and recovers gracefully when an argument expression fails to parse.

**`parser/parser_test.go`**: 4 new test cases:
- `TestFunctionCallMultipleArgs` — `foo(1, 2, 3)`
- `TestFunctionCallTrailingComma` — `foo(1, 2,)`
- `TestFunctionCallNestedCalls` — `foo(bar(1), 2)`
- `TestFunctionCallExpressionArgs` — `foo(1 + 2, x * y)`